### PR TITLE
Add implementation of restrict_zero

### DIFF
--- a/typed_floats/src/types/impls/restrict.rs
+++ b/typed_floats/src/types/impls/restrict.rs
@@ -1,83 +1,87 @@
 use crate::{
-    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN,
-    NonZeroNonNaNFinite, Positive, PositiveFinite, StrictlyNegative, StrictlyNegativeFinite,
-    StrictlyPositive, StrictlyPositiveFinite,
-    RestrictInf, RestrictZero, RestrictPositive, RestrictNegative,
+    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN, NonZeroNonNaNFinite, Positive,
+    PositiveFinite, RestrictInf, RestrictNegative, RestrictPositive, RestrictZero,
+    StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive, StrictlyPositiveFinite,
 };
 
-
 macro_rules! impl_exclude {
-    ($trait:ident, $fn:ident, $check:ident, $type:ident, $output:ident) => {
+    ($trait:ident, $fn:ident, $($check:ident)? $($zero:literal)?, $type:ident, $output:ident) => {
         impl $trait for $type<f32> {
             type Output = $output<f32>;
 
             /// Filters out infinite values.
-            /// 
+            ///
             /// ```
             /// use typed_floats::*;
-            /// 
+            ///
             /// let a: Positive<f32> = 0.0.try_into().unwrap();
             /// let b: PositiveFinite<f32> = a.restrict_inf().unwrap();
             /// let c: PositiveFinite<f32> = match a.restrict_inf() {
-            ///    Ok(x) => x,
-            ///    Err(x) => panic!("{} is infinite", x),
+            /// 	Ok(x) => x,
+            /// 	Err(x) => panic!("{} is infinite", x),
             /// };
             /// ```
             #[inline]
             fn $fn(self) -> Result<Self::Output, Self> {
-                if self.$check() {
+                if
+                $(self.$check())?
+                $($crate::$type::accept_zero() && self.0 == $zero)?
+                {
                     Err(self)
                 } else {
                     Ok(unsafe { $output::<f32>::new_unchecked(self.get()) })
                 }
             }
         }
-        
+
         impl $trait for $type<f64> {
             type Output = $output<f64>;
 
             /// Filters out infinite values.
-            /// 
+            ///
             /// ```
             /// use typed_floats::*;
-            /// 
+            ///
             /// let a: Positive<f64> = 0.0.try_into().unwrap();
             /// let b: PositiveFinite<f64> = a.restrict_inf().unwrap();
             /// ```
             #[inline]
             fn $fn(self) -> Result<Self::Output, Self> {
-                if self.$check() {
+                if
+                $(self.$check())?
+                $($crate::$type::accept_zero() && self.0 == $zero)?
+                {
                     Err(self)
                 } else {
                     Ok(unsafe { $output::<f64>::new_unchecked(self.get()) })
                 }
             }
         }
-    }
+    };
 }
 
 macro_rules! impl_exclude_inf {
     ($type:ident, $output:ident) => {
         impl_exclude!(RestrictInf, restrict_inf, is_infinite, $type, $output);
-    }
+    };
 }
 
 macro_rules! impl_exclude_zero {
     ($type:ident, $output:ident) => {
-        //impl_exclude!(RestrictZero, restrict_zero, is_zero, $type, $output);
-    }
+        impl_exclude!(RestrictZero, restrict_zero, 0.0, $type, $output);
+    };
 }
 
 macro_rules! impl_exclude_positive {
     ($type:ident, $output:ident) => {
         impl_exclude!(RestrictPositive, restrict_positive, is_sign_positive, $type, $output);
-    }
+    };
 }
 
 macro_rules! impl_exclude_negative {
     ($type:ident, $output:ident) => {
         impl_exclude!(RestrictNegative, restrict_negative, is_sign_positive, $type, $output);
-    }
+    };
 }
 
 impl_exclude_inf!(NonNaN, NonNaNFinite);


### PR DESCRIPTION
I think making an `is_zero` is useless as there is `impl PartialEq<f32/f64>`, what do you think of this little hack that avoids adding 19 lines per type?

As per the naming, I don't think badly of restrict, but maybe exclude is better?