### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Most constants are also available, with the most appropriate TypedFloat type (ex
 
 (The traits `From` and `TryFrom` are implemented depending on the situation)
 
-## Comparaisons: [`core::cmp::PartialOrd`] and [`core::cmp::PartialEq`]
+## Comparisons: [`core::cmp::PartialOrd`] and [`core::cmp::PartialEq`]
 | 🗘 | `f32`/`f64` | [`NonNaN`] | [`NonNaNFinite`] | [`NonZeroNonNaN`] | [`NonZeroNonNaNFinite`] | [`Positive`] | [`PositiveFinite`] | [`StrictlyPositive`] | [`StrictlyPositiveFinite`] | [`Negative`] | [`NegativeFinite`] | [`StrictlyNegative`] | [`StrictlyNegativeFinite`]
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | `f32`/`f64` | N/A |  ✔️ |  ✔️ |  ✔️ |  ✔️ |  ✔️ |  ✔️ |  ✔️ |  ✔️ |  ✔️ |  ✔️ |  ✔️ |  ✔️ | 

--- a/typed_floats/build.rs
+++ b/typed_floats/build.rs
@@ -19,7 +19,7 @@ pub fn create_creadmes() {
         .expect("Failed to copy README.md from project root to crate root");
 
     // Truncate the README to include it in the documentation of the crate
-    let trucated_readme = Path::new("../typed_floats/README.truncated.md");
+    let truncated_readme = Path::new("../typed_floats/README.truncated.md");
 
     // remove the parts that are not used by docs.io
     // That truncated version is the introduction of the documentation
@@ -32,7 +32,7 @@ pub fn create_creadmes() {
 
     let text = text.replace("```rust", "```ignore");
 
-    fs::write(trucated_readme, text).expect("Failed to write truncated README.md");
+    fs::write(truncated_readme, text).expect("Failed to write truncated README.md");
 }
 
 fn main() {

--- a/typed_floats/src/lib.rs
+++ b/typed_floats/src/lib.rs
@@ -68,7 +68,7 @@
 //! assert_eq!(b, 1.0);
 //! ```
 //!
-//! Also, comparaison between types is available:
+//! Also, comparison between types is available:
 //!
 //! ```
 //! use typed_floats::*;

--- a/typed_floats/src/macros.rs
+++ b/typed_floats/src/macros.rs
@@ -198,7 +198,7 @@ macro_rules! assert_float_eq {
 /// const SIX: NonNaN<f32> = as_const!(NonNaN, f32, 6.0);
 /// ```
 ///
-/// Thoses examples will panic at compile time:
+/// Those examples will panic at compile time:
 ///
 /// ```ignore
 /// # use typed_floats::*;
@@ -278,7 +278,7 @@ macro_rules! as_const {
 /// generate_const!(INF, StrictlyPositive, f32, 1.0/0.0);
 /// ```
 ///
-/// Thoses examples will panic at compile time:
+/// Those examples will panic at compile time:
 ///
 /// ```ignore
 /// # use typed_floats::*;

--- a/typed_floats_macros/src/impl_self.rs
+++ b/typed_floats_macros/src/impl_self.rs
@@ -197,7 +197,7 @@ pub fn get_impl_self() -> Vec<Op> {
             .description(quote! {
                 /// Returns the fractional part of `self`.
                 /// For negative numbers, the result is negative except when the fractional part is zero.
-                /// For INIFINITY and NEG_INFINITY, the result is NaN.
+                /// For INFINITY and NEG_INFINITY, the result is NaN.
                 ///
                 /// # Examples
                 ///

--- a/typed_floats_macros/src/impl_self_rhs.rs
+++ b/typed_floats_macros/src/impl_self_rhs.rs
@@ -63,7 +63,7 @@ pub fn get_impl_self_rhs() -> Vec<OpRhs> {
         OpRhsBuilder::new("core::ops::Sub", "sub")
             .with_assign("core::ops::SubAssign", "sub_assign")
             .bin_op("-")
-            .comment("The substraction of two infinity of the same sign is `NaN`")
+            .comment("The subtraction of two infinity of the same sign is `NaN`")
             .result(Box::new(|float, rhs| {
                 let spec_a = &float.s;
                 let spec_b = &rhs.s;

--- a/xtask/src/tag.rs
+++ b/xtask/src/tag.rs
@@ -61,7 +61,7 @@ pub fn tag(args: Vec<String>) {
         .output()
         .unwrap();
 
-    println!("Commiting files...");
+    println!("Committing files...");
 
     std::process::Command::new("git")
         .args([


### PR DESCRIPTION
I saw "Comparaisons" when reading the docs, so ran a spell checker and found a few more.