### PR TITLE
Remove "different from zero" from `NonNaNFinite`'s documentation since it can represent zero.

### DIFF
--- a/typed_floats/src/types/mod.rs
+++ b/typed_floats/src/types/mod.rs
@@ -73,7 +73,7 @@ pub struct NonNaN<T = f64>(T);
 #[repr(transparent)]
 pub struct NonZeroNonNaN<T = f64>(T);
 
-/// A non-NaN finite floating point number different from zero
+/// A non-NaN finite floating point number
 ///
 /// It satisfies the following constraints:
 /// - It is not NaN.


### PR DESCRIPTION
I don't think that the docs for `NonNaNFinite` should say that it represents a "A non-NaN finite floating point number different from zero" since it can represent 0. Currently `NonNaNFinite` has the exact same description as `NonZeroNonNaNFinite` which I assume is by mistake.