### PR TITLE
Implement first draft of Normalized

### DIFF
--- a/typed_floats/src/serde.rs
+++ b/typed_floats/src/serde.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Deserializer};
 
 use crate::types::{
-    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN, NonZeroNonNaNFinite, Positive,
-    PositiveFinite, StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive,
+    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN, NonZeroNonNaNFinite, Normalized,
+    Positive, PositiveFinite, StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive,
     StrictlyPositiveFinite,
 };
 
@@ -42,6 +42,7 @@ impl_deserialize!(Positive);
 impl_deserialize!(Negative);
 impl_deserialize!(PositiveFinite);
 impl_deserialize!(NegativeFinite);
+impl_deserialize!(Normalized);
 impl_deserialize!(StrictlyPositive);
 impl_deserialize!(StrictlyNegative);
 impl_deserialize!(StrictlyPositiveFinite);

--- a/typed_floats/src/tf32.rs
+++ b/typed_floats/src/tf32.rs
@@ -12,6 +12,9 @@ pub type NonZeroNonNaN = crate::NonZeroNonNaN<f32>;
 /// Equivalent to `NonZeroNonNaNFinite<f32>`
 pub type NonZeroNonNaNFinite = crate::NonZeroNonNaNFinite<f32>;
 
+/// Equivalent to `NegativeFinite<f32>`
+pub type Normalized = crate::Normalized<f32>;
+
 /// Equivalent to `StrictlyPositive<f32>`
 pub type StrictlyPositive = crate::StrictlyPositive<f32>;
 

--- a/typed_floats/src/tf64.rs
+++ b/typed_floats/src/tf64.rs
@@ -12,6 +12,9 @@ pub type NonZeroNonNaN = crate::NonZeroNonNaN<f64>;
 /// Equivalent to `NonZeroNonNaNFinite<f64>`
 pub type NonZeroNonNaNFinite = crate::NonZeroNonNaNFinite<f64>;
 
+/// Equivalent to `Normalized<f64>`
+pub type Normalized = crate::Normalized<f64>;
+
 /// Equivalent to `StrictlyPositive<f64>`
 pub type StrictlyPositive = crate::StrictlyPositive<f64>;
 

--- a/typed_floats/src/types/f32/mod.rs
+++ b/typed_floats/src/types/f32/mod.rs
@@ -4,6 +4,7 @@ mod non_nan;
 mod non_nan_finite;
 mod non_zero_non_nan;
 mod non_zero_non_nan_finite;
+mod normalized;
 mod positive;
 mod positive_finite;
 mod strictly_negative;

--- a/typed_floats/src/types/f32/normalized.rs
+++ b/typed_floats/src/types/f32/normalized.rs
@@ -1,0 +1,291 @@
+use crate::{
+    InvalidNormalizedNumber,
+    types::{Normalized, f32},
+};
+
+impl Normalized<f32> {
+    /// Creates a new value from a primitive type
+    /// It adds a little overhead compared to `new_unchecked`
+    /// because it checks that the value is valid
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use typed_floats::tf32::Normalized;
+    /// let x = Normalized::new(1.0).unwrap();
+    ///
+    /// assert_eq!(x, 1.0);
+    /// ```
+    ///
+    /// # Errors
+    /// Returns an error if the value is not valid
+    #[inline]
+    pub const fn new(value: f32) -> Result<Self, InvalidNormalizedNumber> {
+        if value.is_nan() {
+            return Err(InvalidNormalizedNumber::NaN);
+        }
+
+        if value.is_sign_negative() {
+            return Err(InvalidNormalizedNumber::Negative);
+        }
+
+        if value > 1.0 {
+            return Err(InvalidNormalizedNumber::BiggerThanOne);
+        }
+
+        Ok(Self(value))
+    }
+
+    /// Creates a new value from a primitive type with zero overhead (in release mode).
+    /// It is up to the caller to ensure that the value is valid
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use typed_floats::tf32::Normalized;
+    /// let x = unsafe { Normalized::new_unchecked(0.5) };
+    ///
+    /// assert_eq!(x, 0.5);
+    /// ```
+    /// # Safety
+    /// The caller must ensure that the value is valid.
+    /// It will panic in debug mode if the value is not valid,
+    /// but in release mode the behavior is undefined
+    #[inline]
+    #[must_use]
+    pub const unsafe fn new_unchecked(value: f32) -> Self {
+        crate::macros::new_unchecked!(value, Normalized)
+    }
+
+    /// Returns the value as a primitive type
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    ///
+    /// let x = Normalized::new(1.0).unwrap();
+    ///
+    /// let y: f32 = x.into();
+    ///
+    /// assert_eq!(y, 1.0);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn get(&self) -> f32 {
+        self.0
+    }
+
+    /// Returns `true` if this value is NaN.
+    /// This is never the case for the provided types
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 0.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_nan(), false);
+    /// ```
+    ///
+    /// See [`f32::is_nan()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_nan(&self) -> bool {
+        false
+    }
+
+    /// Returns `true` if this value is positive infinity or negative infinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_infinite(), false);
+    /// ```
+    ///
+    /// See [`f32::is_infinite()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_infinite(&self) -> bool {
+        false
+    }
+
+    /// Returns `true` if this number is positive infinity nor negative infinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 0.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_finite(), true);
+    /// ```
+    ///
+    /// See [`f32::is_finite()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_finite(&self) -> bool {
+        true
+    }
+
+    /// Returns `true` if the number is [subnormal](https://en.wikipedia.org/wiki/Denormal_number).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 0.5.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_subnormal(), false);
+    /// ```
+    ///
+    /// See [`f32::is_subnormal()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_subnormal(&self) -> bool {
+        self.0.is_subnormal()
+    }
+
+    /// Returns `true` if the number is neither zero, infinite or [subnormal](https://en.wikipedia.org/wiki/Denormal_number).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_normal(), true);
+    /// ```
+    ///
+    /// See [`f32::is_normal()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_normal(&self) -> bool {
+        self.0.is_normal()
+    }
+
+    /// Returns the floating point category of the number. If only one property
+    /// is going to be tested, it is generally faster to use the specific
+    /// predicate instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 0.5.try_into().unwrap();
+    ///
+    /// assert_eq!(x.classify(), core::num::FpCategory::Normal);
+    /// ```
+    ///
+    /// See [`f32::classify()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn classify(&self) -> core::num::FpCategory {
+        self.0.classify()
+    }
+
+    /// Returns `true` if `self` has a positive sign, including `+0.0` and positive infinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 0.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_sign_positive(), true);
+    /// ```
+    ///
+    /// See [`f32::is_sign_positive()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_sign_positive(&self) -> bool {
+        true
+    }
+
+    /// Returns `true` if `self` has a negative sign, including `-0.0` and negative infinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_sign_negative(), false);
+    /// ```
+    ///
+    /// See [`f32::is_sign_negative()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_sign_negative(&self) -> bool {
+        false
+    }
+
+    /// Returns `true` if the number is negative zero.
+    ///     
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_negative_zero(), false);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn is_negative_zero(&self) -> bool {
+        false
+    }
+
+    /// Returns `true` if the number is positive zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf32::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_positive_zero(), false);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn is_positive_zero(&self) -> bool {
+        self.0 == 0.0
+    }
+}
+
+impl core::ops::Mul<f32> for Normalized<f32> {
+    type Output = f32;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        self.0 * rhs
+    }
+}
+
+macro_rules! mul {
+    ($rhs:ident) => {
+        impl core::ops::Mul<crate::types::$rhs<f32>> for Normalized<f32> {
+            type Output = crate::types::$rhs<f32>;
+
+            fn mul(self, rhs: crate::types::$rhs<f32>) -> Self::Output {
+                crate::types::$rhs::<f32>(self.0 * rhs.0)
+            }
+        }
+    };
+}
+
+mul!(Negative);
+mul!(NegativeFinite);
+mul!(NonNaN);
+mul!(NonNaNFinite);
+mul!(NonZeroNonNaN);
+mul!(NonZeroNonNaNFinite);
+mul!(Positive);
+mul!(PositiveFinite);
+mul!(StrictlyNegativeFinite);
+mul!(StrictlyNegative);
+mul!(StrictlyPositiveFinite);
+mul!(StrictlyPositive);
+mul!(Normalized);

--- a/typed_floats/src/types/f64/mod.rs
+++ b/typed_floats/src/types/f64/mod.rs
@@ -4,6 +4,7 @@ mod non_nan;
 mod non_nan_finite;
 mod non_zero_non_nan;
 mod non_zero_non_nan_finite;
+mod normalized;
 mod positive;
 mod positive_finite;
 mod strictly_negative;

--- a/typed_floats/src/types/f64/normalized.rs
+++ b/typed_floats/src/types/f64/normalized.rs
@@ -1,0 +1,291 @@
+use crate::{
+    InvalidNormalizedNumber,
+    types::{Normalized, f64},
+};
+
+impl Normalized<f64> {
+    /// Creates a new value from a primitive type
+    /// It adds a little overhead compared to `new_unchecked`
+    /// because it checks that the value is valid
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use typed_floats::tf64::Normalized;
+    /// let x = Normalized::new(1.0).unwrap();
+    ///
+    /// assert_eq!(x, 1.0);
+    /// ```
+    ///
+    /// # Errors
+    /// Returns an error if the value is not valid
+    #[inline]
+    pub const fn new(value: f64) -> Result<Self, InvalidNormalizedNumber> {
+        if value.is_nan() {
+            return Err(InvalidNormalizedNumber::NaN);
+        }
+
+        if value.is_sign_negative() {
+            return Err(InvalidNormalizedNumber::Negative);
+        }
+
+        if value > 1.0 {
+            return Err(InvalidNormalizedNumber::BiggerThanOne);
+        }
+
+        Ok(Self(value))
+    }
+
+    /// Creates a new value from a primitive type with zero overhead (in release mode).
+    /// It is up to the caller to ensure that the value is valid
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use typed_floats::tf64::Normalized;
+    /// let x = unsafe { Normalized::new_unchecked(0.5) };
+    ///
+    /// assert_eq!(x, 0.5);
+    /// ```
+    /// # Safety
+    /// The caller must ensure that the value is valid.
+    /// It will panic in debug mode if the value is not valid,
+    /// but in release mode the behavior is undefined
+    #[inline]
+    #[must_use]
+    pub const unsafe fn new_unchecked(value: f64) -> Self {
+        crate::macros::new_unchecked!(value, Normalized)
+    }
+
+    /// Returns the value as a primitive type
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    ///
+    /// let x = Normalized::new(1.0).unwrap();
+    ///
+    /// let y: f64 = x.into();
+    ///
+    /// assert_eq!(y, 1.0);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn get(&self) -> f64 {
+        self.0
+    }
+
+    /// Returns `true` if this value is NaN.
+    /// This is never the case for the provided types
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 0.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_nan(), false);
+    /// ```
+    ///
+    /// See [`f64::is_nan()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_nan(&self) -> bool {
+        false
+    }
+
+    /// Returns `true` if this value is positive infinity or negative infinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_infinite(), false);
+    /// ```
+    ///
+    /// See [`f64::is_infinite()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_infinite(&self) -> bool {
+        false
+    }
+
+    /// Returns `true` if this number is positive infinity nor negative infinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 0.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_finite(), true);
+    /// ```
+    ///
+    /// See [`f64::is_finite()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_finite(&self) -> bool {
+        true
+    }
+
+    /// Returns `true` if the number is [subnormal](https://en.wikipedia.org/wiki/Denormal_number).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 0.5.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_subnormal(), false);
+    /// ```
+    ///
+    /// See [`f64::is_subnormal()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_subnormal(&self) -> bool {
+        self.0.is_subnormal()
+    }
+
+    /// Returns `true` if the number is neither zero, infinite or [subnormal](https://en.wikipedia.org/wiki/Denormal_number).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_normal(), true);
+    /// ```
+    ///
+    /// See [`f64::is_normal()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_normal(&self) -> bool {
+        self.0.is_normal()
+    }
+
+    /// Returns the floating point category of the number. If only one property
+    /// is going to be tested, it is generally faster to use the specific
+    /// predicate instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 0.5.try_into().unwrap();
+    ///
+    /// assert_eq!(x.classify(), core::num::FpCategory::Normal);
+    /// ```
+    ///
+    /// See [`f64::classify()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn classify(&self) -> core::num::FpCategory {
+        self.0.classify()
+    }
+
+    /// Returns `true` if `self` has a positive sign, including `+0.0` and positive infinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 0.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_sign_positive(), true);
+    /// ```
+    ///
+    /// See [`f64::is_sign_positive()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_sign_positive(&self) -> bool {
+        true
+    }
+
+    /// Returns `true` if `self` has a negative sign, including `-0.0` and negative infinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_sign_negative(), false);
+    /// ```
+    ///
+    /// See [`f64::is_sign_negative()`] for more details.
+    #[inline]
+    #[must_use]
+    pub const fn is_sign_negative(&self) -> bool {
+        false
+    }
+
+    /// Returns `true` if the number is negative zero.
+    ///     
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_negative_zero(), false);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn is_negative_zero(&self) -> bool {
+        false
+    }
+
+    /// Returns `true` if the number is positive zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use typed_floats::tf64::Normalized;
+    /// let x: Normalized = 1.0.try_into().unwrap();
+    ///
+    /// assert_eq!(x.is_positive_zero(), false);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn is_positive_zero(&self) -> bool {
+        self.0 == 0.0
+    }
+}
+
+impl core::ops::Mul<f64> for Normalized<f64> {
+    type Output = f64;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        self.0 * rhs
+    }
+}
+
+macro_rules! mul {
+    ($rhs:ident) => {
+        impl core::ops::Mul<crate::types::$rhs<f64>> for Normalized<f64> {
+            type Output = crate::types::$rhs<f64>;
+
+            fn mul(self, rhs: crate::types::$rhs<f64>) -> Self::Output {
+                crate::types::$rhs::<f64>(self.0 * rhs.0)
+            }
+        }
+    };
+}
+
+mul!(Negative);
+mul!(NegativeFinite);
+mul!(NonNaN);
+mul!(NonNaNFinite);
+mul!(NonZeroNonNaN);
+mul!(NonZeroNonNaNFinite);
+mul!(Positive);
+mul!(PositiveFinite);
+mul!(StrictlyNegativeFinite);
+mul!(StrictlyNegative);
+mul!(StrictlyPositiveFinite);
+mul!(StrictlyPositive);
+mul!(Normalized);

--- a/typed_floats/src/types/impls/display.rs
+++ b/typed_floats/src/types/impls/display.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN, NonZeroNonNaNFinite, Positive,
-    PositiveFinite, StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive,
+    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN, NonZeroNonNaNFinite, Normalized,
+    Positive, PositiveFinite, StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive,
     StrictlyPositiveFinite,
 };
 
@@ -55,6 +55,7 @@ impl_display!(non_nan, NonNaN);
 impl_display!(non_zero_non_nan, NonZeroNonNaN);
 impl_display!(non_nan_finite, NonNaNFinite);
 impl_display!(non_zero_non_nan_finite, NonZeroNonNaNFinite);
+impl_display!(normalized, Normalized);
 impl_display!(positive, Positive);
 impl_display!(negative, Negative);
 impl_display!(positive_finite, PositiveFinite);

--- a/typed_floats/src/types/impls/eq.rs
+++ b/typed_floats/src/types/impls/eq.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN, NonZeroNonNaNFinite, Positive,
-    PositiveFinite, StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive,
+    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN, NonZeroNonNaNFinite, Normalized,
+    Positive, PositiveFinite, StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive,
     StrictlyPositiveFinite,
 };
 
@@ -125,6 +125,9 @@ impl_eq_self!(NonNaNFinite);
 
 impl_fast_eq_base!(NonZeroNonNaNFinite);
 impl_fast_eq_self!(NonZeroNonNaNFinite);
+
+impl_fast_eq_base!(Normalized);
+impl_fast_eq_self!(Normalized);
 
 impl_eq_base!(Positive);
 impl_fast_eq_self!(Positive);

--- a/typed_floats/src/types/impls/from_str.rs
+++ b/typed_floats/src/types/impls/from_str.rs
@@ -1,32 +1,32 @@
 use crate::{
     FromStrError, Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN,
-    NonZeroNonNaNFinite, Positive, PositiveFinite, StrictlyNegative, StrictlyNegativeFinite,
-    StrictlyPositive, StrictlyPositiveFinite,
+    NonZeroNonNaNFinite, Normalized, NormalizedFromStrError, Positive, PositiveFinite,
+    StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive, StrictlyPositiveFinite,
 };
 
 macro_rules! impl_from_str {
-    ($test:ident, $type:ident) => {
+    ($test:ident, $type:ident, $error:ident) => {
         #[cfg(feature = "f32")]
         impl core::str::FromStr for $type<f32> {
-            type Err = FromStrError;
+            type Err = $error;
 
             #[inline]
             fn from_str(s: &str) -> Result<Self, Self::Err> {
-                let f: f32 = s.parse::<f32>().map_err(FromStrError::ParseFloatError)?;
+                let f: f32 = s.parse::<f32>().map_err($error::ParseFloatError)?;
 
-                Self::try_from(f).map_err(FromStrError::InvalidNumber)
+                Self::try_from(f).map_err(Self::Err::InvalidNumber)
             }
         }
 
         #[cfg(feature = "f64")]
         impl core::str::FromStr for $type<f64> {
-            type Err = FromStrError;
+            type Err = $error;
 
             #[inline]
             fn from_str(s: &str) -> Result<Self, Self::Err> {
-                let f: f64 = s.parse::<f64>().map_err(FromStrError::ParseFloatError)?;
+                let f: f64 = s.parse::<f64>().map_err($error::ParseFloatError)?;
 
-                Self::try_from(f).map_err(FromStrError::InvalidNumber)
+                Self::try_from(f).map_err(Self::Err::InvalidNumber)
             }
         }
 
@@ -65,15 +65,24 @@ macro_rules! impl_from_str {
     };
 }
 
-impl_from_str!(non_nan, NonNaN);
-impl_from_str!(non_zero_non_nan, NonZeroNonNaN);
-impl_from_str!(non_nan_finite, NonNaNFinite);
-impl_from_str!(non_zero_non_nan_finite, NonZeroNonNaNFinite);
-impl_from_str!(positive, Positive);
-impl_from_str!(negative, Negative);
-impl_from_str!(positive_finite, PositiveFinite);
-impl_from_str!(negative_finite, NegativeFinite);
-impl_from_str!(strictly_positive, StrictlyPositive);
-impl_from_str!(strictly_negative, StrictlyNegative);
-impl_from_str!(strictly_positive_finite, StrictlyPositiveFinite);
-impl_from_str!(strictly_negative_finite, StrictlyNegativeFinite);
+impl_from_str!(non_nan, NonNaN, FromStrError);
+impl_from_str!(non_zero_non_nan, NonZeroNonNaN, FromStrError);
+impl_from_str!(non_nan_finite, NonNaNFinite, FromStrError);
+impl_from_str!(non_zero_non_nan_finite, NonZeroNonNaNFinite, FromStrError);
+impl_from_str!(normalized, Normalized, NormalizedFromStrError);
+impl_from_str!(positive, Positive, FromStrError);
+impl_from_str!(negative, Negative, FromStrError);
+impl_from_str!(positive_finite, PositiveFinite, FromStrError);
+impl_from_str!(negative_finite, NegativeFinite, FromStrError);
+impl_from_str!(strictly_positive, StrictlyPositive, FromStrError);
+impl_from_str!(strictly_negative, StrictlyNegative, FromStrError);
+impl_from_str!(
+    strictly_positive_finite,
+    StrictlyPositiveFinite,
+    FromStrError
+);
+impl_from_str!(
+    strictly_negative_finite,
+    StrictlyNegativeFinite,
+    FromStrError
+);

--- a/typed_floats/src/types/impls/from_to/floats.rs
+++ b/typed_floats/src/types/impls/from_to/floats.rs
@@ -1,11 +1,11 @@
 use crate::{
-    InvalidNumber, Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN,
-    NonZeroNonNaNFinite, Positive, PositiveFinite, StrictlyNegative, StrictlyNegativeFinite,
-    StrictlyPositive, StrictlyPositiveFinite,
+    InvalidNormalizedNumber, InvalidNumber, Negative, NegativeFinite, NonNaN, NonNaNFinite,
+    NonZeroNonNaN, NonZeroNonNaNFinite, Normalized, Positive, PositiveFinite, StrictlyNegative,
+    StrictlyNegativeFinite, StrictlyPositive, StrictlyPositiveFinite,
 };
 
 macro_rules! impl_from {
-    ($test:ident, $type:ident) => {
+    ($test:ident, $type:ident, $error:ident) => {
         #[cfg(feature = "f32")]
         impl From<$type<Self>> for f32 {
             #[inline]
@@ -24,7 +24,7 @@ macro_rules! impl_from {
 
         #[cfg(feature = "f32")]
         impl TryFrom<f32> for $type<f32> {
-            type Error = InvalidNumber;
+            type Error = $error;
 
             #[inline]
             fn try_from(value: f32) -> Result<Self, Self::Error> {
@@ -34,7 +34,7 @@ macro_rules! impl_from {
 
         #[cfg(feature = "f64")]
         impl TryFrom<f64> for $type<f64> {
-            type Error = InvalidNumber;
+            type Error = $error;
 
             #[inline]
             fn try_from(value: f64) -> Result<Self, Self::Error> {
@@ -70,15 +70,24 @@ macro_rules! impl_from {
     };
 }
 
-impl_from!(non_nan, NonNaN);
-impl_from!(non_zero_non_nan, NonZeroNonNaN);
-impl_from!(non_nan_finite, NonNaNFinite);
-impl_from!(non_zero_non_nan_finite, NonZeroNonNaNFinite);
-impl_from!(positive, Positive);
-impl_from!(negative, Negative);
-impl_from!(positive_finite, PositiveFinite);
-impl_from!(negative_finite, NegativeFinite);
-impl_from!(strictly_positive, StrictlyPositive);
-impl_from!(strictly_negative, StrictlyNegative);
-impl_from!(strictly_positive_finite, StrictlyPositiveFinite);
-impl_from!(strictly_negative_finite, StrictlyNegativeFinite);
+impl_from!(non_nan, NonNaN, InvalidNumber);
+impl_from!(non_zero_non_nan, NonZeroNonNaN, InvalidNumber);
+impl_from!(non_nan_finite, NonNaNFinite, InvalidNumber);
+impl_from!(non_zero_non_nan_finite, NonZeroNonNaNFinite, InvalidNumber);
+impl_from!(normalized, Normalized, InvalidNormalizedNumber);
+impl_from!(positive, Positive, InvalidNumber);
+impl_from!(negative, Negative, InvalidNumber);
+impl_from!(positive_finite, PositiveFinite, InvalidNumber);
+impl_from!(negative_finite, NegativeFinite, InvalidNumber);
+impl_from!(strictly_positive, StrictlyPositive, InvalidNumber);
+impl_from!(strictly_negative, StrictlyNegative, InvalidNumber);
+impl_from!(
+    strictly_positive_finite,
+    StrictlyPositiveFinite,
+    InvalidNumber
+);
+impl_from!(
+    strictly_negative_finite,
+    StrictlyNegativeFinite,
+    InvalidNumber
+);

--- a/typed_floats/src/types/impls/ord.rs
+++ b/typed_floats/src/types/impls/ord.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::comparison_chain)]
 
 use crate::{
-    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN, NonZeroNonNaNFinite, Positive,
-    PositiveFinite, StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive,
+    Negative, NegativeFinite, NonNaN, NonNaNFinite, NonZeroNonNaN, NonZeroNonNaNFinite, Normalized,
+    Positive, PositiveFinite, StrictlyNegative, StrictlyNegativeFinite, StrictlyPositive,
     StrictlyPositiveFinite,
 };
 
@@ -136,6 +136,7 @@ impl_ord!(NonNaN);
 impl_ord!(NonZeroNonNaN);
 impl_ord!(NonNaNFinite);
 impl_ord!(NonZeroNonNaNFinite);
+impl_fast_inv_ord!(Normalized);
 impl_fast_ord!(Positive);
 impl_fast_inv_ord!(Negative);
 impl_fast_ord!(PositiveFinite);
@@ -149,6 +150,7 @@ impl_partial_ord!(NonNaN);
 impl_partial_ord!(NonZeroNonNaN);
 impl_partial_ord!(NonNaNFinite);
 impl_partial_ord!(NonZeroNonNaNFinite);
+impl_partial_ord!(Normalized);
 impl_partial_ord!(Positive);
 impl_partial_ord!(Negative);
 impl_partial_ord!(PositiveFinite);

--- a/typed_floats/src/types/mod.rs
+++ b/typed_floats/src/types/mod.rs
@@ -19,6 +19,27 @@ impl core::fmt::Display for FromStrError {
 #[cfg(feature = "std")]
 impl std::error::Error for FromStrError {}
 
+/// An error that can occur when converting from a string into a typed float
+#[derive(Debug)]
+pub enum NormalizedFromStrError {
+    /// The string did not contain a valid float number
+    ParseFloatError(core::num::ParseFloatError),
+    /// The string contained a valid float number but it didn't fit in the target type
+    InvalidNumber(InvalidNormalizedNumber),
+}
+
+impl core::fmt::Display for NormalizedFromStrError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ParseFloatError(e) => write!(f, "{e}"),
+            Self::InvalidNumber(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NormalizedFromStrError {}
+
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
@@ -51,6 +72,30 @@ impl core::fmt::Display for InvalidNumber {
 
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidNumber {}
+
+/// An error that can occur when converting into a Normalized
+#[derive(Debug, Eq, PartialEq)]
+pub enum InvalidNormalizedNumber {
+    /// Any variant of `Nan`
+    NaN,
+    /// Any negative number, including `-0.0` and `-inf`
+    Negative,
+    /// `Any positive number bigger +1.0`
+    BiggerThanOne,
+}
+
+impl core::fmt::Display for InvalidNormalizedNumber {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NaN => write!(f, "Number is NaN"),
+            Self::Negative => write!(f, "Number is negative"),
+            Self::BiggerThanOne => write!(f, "Number is bigger than 1.0"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidNormalizedNumber {}
 
 /// A non-NaN floating point number
 ///
@@ -175,6 +220,17 @@ pub struct StrictlyPositiveFinite<T = f64>(T);
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
 pub struct StrictlyNegativeFinite<T = f64>(T);
+
+/// A non-NaN positive finite floating point number between 0..=1
+///
+/// It satisfies the following constraints:
+/// - It is not NaN.
+/// - It is not infinite
+/// - It is not negative
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+pub struct Normalized<T = f64>(T);
 
 use crate::traits::{Max, Min};
 


### PR DESCRIPTION
Because of the positive reaction in https://github.com/tdelmas/typed_floats/issues/307, I hereby submit a first draft of `Normalized`.
Beside validation and functions which all wrappers seem to have, it implements Mul<T> for all Wrappers and the plain float value. It doesn't implement other operations, as multiplication is often the only operation which makes sense.

In order to introduce no breaking changes, `NormalizedFromStdError` and `InvalidNormalizedNumber` were introduced, to represent the error BiggerThanOne… Have you ever considered adding dedicated Error variants to all Types, so only Error-Variants which can actually happen when creating that type are returned?

I was thinking about adding a `normalized` feature-flag, so compile times, which are high already, don't increase further. What do you think about this?

