### PR TITLE
Change README table for struct comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,24 @@ And their positive and negative counterparts:
 - [`Positive`],[`PositiveFinite`], [`StrictlyPositive`], [`StrictlyPositiveFinite`]
 - [`Negative`],[`NegativeFinite`], [`StrictlyNegative`], [`StrictlyNegativeFinite`]
 
-| Type | `-∞` | `]-∞; -0.0[` | `-0.0` | `+0.0` | `]+0.0; +∞[` | `+∞` | `NaN` |
-|---|---|---|---|---|---|---|---|
-| [`NonNaN`] | ✔️ | ✔️ | ✔️ | ✔️  | ✔️ | ✔️ | ❌ |
-| [`NonNaNFinite`] | ❌ | ✔️ | ✔️ | ✔️ | ✔️ | ❌ |  ❌ |
-| [`NonZeroNonNaN`] | ✔️ | ✔️ | ❌ | ❌ | ✔️ | ✔️ |  ❌ |
-| [`NonZeroNonNaNFinite`] | ❌ | ✔️ | ❌ | ❌ | ✔️ | ❌ | ❌ |
-| [`Positive`] | ❌ | ❌ | ❌ | ✔️ | ✔️ | ✔️ | ❌ |
-| [`PositiveFinite`] | ❌ | ❌ | ❌ | ✔️ | ✔️ | ❌ | ❌ |
-| [`StrictlyPositive`] | ❌ | ❌ | ❌ | ❌ | ✔️ | ✔️ | ❌ |
-| [`StrictlyPositiveFinite`] | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ | ❌ |
-| [`Negative`] | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
-| [`NegativeFinite`] | ❌ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
-| [`StrictlyNegative`] | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| [`StrictlyNegativeFinite`] | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
+<pre>
+┊ -∞ ┊ .. ┊ -0 ┊ +0 ┊ .. ┊ +∞ ┊ (NaN is never accepted)
+┊    ┊    ┊    ┊    ┊    ┊    ┊
+┊<━━━┊━━━━┊━━━━┊━━━━┊━━━━┊━━━>┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonNaN.html">NonNaN</a>
+┊    ┊<━━━┊━━━━┊━━━━┊━━━>┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonNaNFinite.html">NonNaNFinite</a>
+┊<━━━┊━━━>┊    ┊    ┊<━━━┊━━━>┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonZeroNonNaN.html">NonZeroNonNaN</a>
+┊    ┊<━━>┊    ┊    ┊<━━>┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonZeroNonNaNFinite.html">NonZeroNonNaNFinite</a>
+┊    ┊    ┊    ┊    ┊    ┊    ┊
+┊    ┊    ┊    ┊<━━━┊━━━━┊━━━>┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.Positive.html">Positive</a>
+┊    ┊    ┊    ┊<━━━┊━━━>┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.PositiveFinite.html">PositiveFinite</a>
+┊    ┊    ┊    ┊    ┊<━━━┊━━━>┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyPositive.html">StrictlyPositive</a>
+┊    ┊    ┊    ┊    ┊<━━>┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyPositiveFinite.html">StrictlyPositiveFinite</a>
+┊    ┊    ┊    ┊    ┊    ┊    ┊
+┊<━━━┊━━━━┊━━━>┊    ┊    ┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.Negative.html">Negative</a>
+┊    ┊<━━━┊━━━>┊    ┊    ┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NegativeFinite.html">NegativeFinite</a>
+┊<━━━┊━━━>┊    ┊    ┊    ┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyNegative.html">StrictlyNegative</a>
+┊    ┊<━━>┊    ┊    ┊    ┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyNegativeFinite.html">StrictlyNegativeFinite</a>
+</pre>
 
 To avoid specifying the kind of float (e.g. like [`Positive<f32>`]), you can use the modules [`tf64`] and [`tf32`] which expose aliases.
 

--- a/README.md
+++ b/README.md
@@ -36,20 +36,20 @@ And their positive and negative counterparts:
 <pre>
 ┊ -∞ ┊ .. ┊ -0 ┊ +0 ┊ .. ┊ +∞ ┊ (NaN is never accepted)
 ┊    ┊    ┊    ┊    ┊    ┊    ┊
-┊<━━━┊━━━━┊━━━━┊━━━━┊━━━━┊━━━>┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonNaN.html">NonNaN</a>
-┊    ┊<━━━┊━━━━┊━━━━┊━━━>┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonNaNFinite.html">NonNaNFinite</a>
-┊<━━━┊━━━>┊    ┊    ┊<━━━┊━━━>┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonZeroNonNaN.html">NonZeroNonNaN</a>
-┊    ┊<━━>┊    ┊    ┊<━━>┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonZeroNonNaNFinite.html">NonZeroNonNaNFinite</a>
+┊<━━━┊━━━━┊━━━━┊━━━━┊━━━━┊━━━>┊ <a title="[−∞, +∞]" href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonNaN.html">NonNaN</a>
+┊    ┊<━━━┊━━━━┊━━━━┊━━━>┊    ┊ <a title="(−∞, +∞)" href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonNaNFinite.html">NonNaNFinite</a>
+┊<━━━┊━━━>┊    ┊    ┊<━━━┊━━━>┊ <a title="[−∞, 0) ∪ (0, +∞]" href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonZeroNonNaN.html">NonZeroNonNaN</a>
+┊    ┊<━━>┊    ┊    ┊<━━>┊    ┊ <a title="(−∞, 0) ∪ (0, +∞)" href="https://docs.rs/typed_floats/latest/typed_floats/struct.NonZeroNonNaNFinite.html">NonZeroNonNaNFinite</a>
 ┊    ┊    ┊    ┊    ┊    ┊    ┊
-┊    ┊    ┊    ┊<━━━┊━━━━┊━━━>┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.Positive.html">Positive</a>
-┊    ┊    ┊    ┊<━━━┊━━━>┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.PositiveFinite.html">PositiveFinite</a>
-┊    ┊    ┊    ┊    ┊<━━━┊━━━>┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyPositive.html">StrictlyPositive</a>
-┊    ┊    ┊    ┊    ┊<━━>┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyPositiveFinite.html">StrictlyPositiveFinite</a>
+┊    ┊    ┊    ┊<━━━┊━━━━┊━━━>┊ <a title="[0, +∞]" href="https://docs.rs/typed_floats/latest/typed_floats/struct.Positive.html">Positive</a>
+┊    ┊    ┊    ┊<━━━┊━━━>┊    ┊ <a title="[0, +∞)" href="https://docs.rs/typed_floats/latest/typed_floats/struct.PositiveFinite.html">PositiveFinite</a>
+┊    ┊    ┊    ┊    ┊<━━━┊━━━>┊ <a title="(0, +∞]" href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyPositive.html">StrictlyPositive</a>
+┊    ┊    ┊    ┊    ┊<━━>┊    ┊ <a title="(0, +∞)" href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyPositiveFinite.html">StrictlyPositiveFinite</a>
 ┊    ┊    ┊    ┊    ┊    ┊    ┊
-┊<━━━┊━━━━┊━━━>┊    ┊    ┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.Negative.html">Negative</a>
-┊    ┊<━━━┊━━━>┊    ┊    ┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.NegativeFinite.html">NegativeFinite</a>
-┊<━━━┊━━━>┊    ┊    ┊    ┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyNegative.html">StrictlyNegative</a>
-┊    ┊<━━>┊    ┊    ┊    ┊    ┊ <a href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyNegativeFinite.html">StrictlyNegativeFinite</a>
+┊<━━━┊━━━━┊━━━>┊    ┊    ┊    ┊ <a title="[−∞, 0]" href="https://docs.rs/typed_floats/latest/typed_floats/struct.Negative.html">Negative</a>
+┊    ┊<━━━┊━━━>┊    ┊    ┊    ┊ <a title="(−∞, 0]" href="https://docs.rs/typed_floats/latest/typed_floats/struct.NegativeFinite.html">NegativeFinite</a>
+┊<━━━┊━━━>┊    ┊    ┊    ┊    ┊ <a title="[−∞, 0)" href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyNegative.html">StrictlyNegative</a>
+┊    ┊<━━>┊    ┊    ┊    ┊    ┊ <a title="(−∞, 0)" href="https://docs.rs/typed_floats/latest/typed_floats/struct.StrictlyNegativeFinite.html">StrictlyNegativeFinite</a>
 </pre>
 
 To avoid specifying the kind of float (e.g. like [`Positive<f32>`]), you can use the modules [`tf64`] and [`tf32`] which expose aliases.


### PR DESCRIPTION
I find the table with the emojis a bit difficult to parse whenever I read the docs.
This will hopefully be easier for others too.
 
Before:
<img width="1402" height="1226" alt="image" src="https://github.com/user-attachments/assets/6929bf3c-bb5a-43aa-bc10-7ee4d8be6ab1" />

After:
<img width="1437" height="1034" alt="image" src="https://github.com/user-attachments/assets/b50361fd-b676-4f70-bce8-30bd3d73047e" />
